### PR TITLE
Pass submission result to redux-form submit handler

### DIFF
--- a/src/routinePromiseWatcherSaga.js
+++ b/src/routinePromiseWatcherSaga.js
@@ -25,7 +25,7 @@ export function* handleRoutinePromiseAction(action) {
   ]);
 
   if (success) {
-    yield reduxFormCompatible ? call(resolve) : call(resolve, getPayload(success));
+    yield call(resolve, getPayload(success));
   } else {
     yield call(reject, getPayload(failure));
   }


### PR DESCRIPTION
Currently, submit handler in redux form supports submission result returned by `onSubmit` handler. For example, https://redux-form.com/7.2.3/docs/api/reduxform.md/#-code-onsubmitsuccess-function-code-optional-

These changes propose passing submission result to the `onSubmit` handler